### PR TITLE
runner: XPS reliability automation (systemd + watchdog + health issue)

### DIFF
--- a/.github/actions/report-runner-health/action.yml
+++ b/.github/actions/report-runner-health/action.yml
@@ -1,0 +1,252 @@
+name: 'Report runner health'
+description: >-
+  Open / update a single sticky GitHub issue that mirrors the current state of
+  the MorphoClaw self-hosted runner. The issue title is
+  `Runner health: <runner-name>` and it carries the `runner-health` label.
+  A machine-readable JSON block is embedded between AUTO-DATA markers so
+  multiple probes (runner-smoke, bootstrap, liveness) can each update only
+  their own field while preserving the rest.
+
+inputs:
+  runner-name:
+    description: Runner name (used in the issue title, e.g. DellXPS-wsl-gpu)
+    required: true
+  probe-name:
+    description: >-
+      Which probe is reporting. Recommended values: runner-smoke, bootstrap,
+      liveness. The probe gets its own slot in the issue body's JSON state.
+    required: true
+  status:
+    description: 'success | failure | offline | recovered'
+    required: true
+  context:
+    description: >-
+      Optional short markdown snippet appended as a comment on failure / offline
+      (e.g. last 40 lines of a log, link to a workflow run).
+    required: false
+    default: ''
+  github-token:
+    description: GITHUB_TOKEN with issues:write
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v8
+      env:
+        RUNNER_NAME: ${{ inputs.runner-name }}
+        PROBE_NAME:  ${{ inputs.probe-name }}
+        PROBE_STATUS: ${{ inputs.status }}
+        PROBE_CONTEXT: ${{ inputs.context }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const runner = process.env.RUNNER_NAME;
+          const probe  = process.env.PROBE_NAME;
+          const status = process.env.PROBE_STATUS;
+          const ctx    = process.env.PROBE_CONTEXT || '';
+
+          const LABEL  = 'runner-health';
+          const TITLE  = `Runner health: ${runner}`;
+          const NOW    = new Date().toISOString();
+          const RUN_URL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const RUN_REF = `[run ${context.runId}](${RUN_URL})`;
+          const MARK_S = '<!-- AUTO-DATA-START -->';
+          const MARK_E = '<!-- AUTO-DATA-END -->';
+
+          // ---- 1. Ensure the label exists -------------------------------
+          try {
+            await github.rest.issues.getLabel({ ...context.repo, name: LABEL });
+          } catch (e) {
+            if (e.status === 404) {
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: LABEL,
+                color: 'd93f0b',
+                description: 'Tracks the live state of a self-hosted runner.',
+              });
+            }
+          }
+
+          // ---- 2. Find the sticky issue (open or closed) -----------------
+          // Label-based listing — quota-friendly, no Search API dependency.
+          // On the very first invocation, no issue carries the label yet,
+          // so this returns []; we'll create the issue on a bad event.
+          const labelled = await github.paginate(
+            github.rest.issues.listForRepo,
+            { ...context.repo, labels: LABEL, state: 'all', per_page: 100 },
+          );
+          let issue = labelled.find(i => i.title === TITLE && !i.pull_request) || null;
+
+          // ---- 3. Read current state ------------------------------------
+          let state = {
+            runner,
+            probes: {},
+            last_offline_at: null,
+            last_offline_run: null,
+          };
+          let trailingNotes = '';
+          if (issue) {
+            const body = issue.body || '';
+            const s = body.indexOf(MARK_S);
+            const e = body.indexOf(MARK_E);
+            if (s !== -1 && e !== -1 && e > s) {
+              const block = body.slice(s + MARK_S.length, e);
+              const m = block.match(/```json\s*([\s\S]*?)\s*```/);
+              if (m) {
+                try { state = { ...state, ...JSON.parse(m[1]) }; } catch (_) {}
+              }
+              const tail = body.slice(e + MARK_E.length).trim();
+              if (tail) trailingNotes = tail;
+            } else {
+              // First time we've touched this pre-existing issue: keep its
+              // existing body as trailing notes so a human's commentary survives.
+              trailingNotes = body.trim();
+            }
+          }
+
+          // ---- 4. Apply update for this probe ---------------------------
+          if (!state.probes[probe]) {
+            state.probes[probe] = {
+              last_result: null,
+              last_pass_at: null,
+              last_pass_run: null,
+              last_fail_at: null,
+              last_fail_run: null,
+            };
+          }
+          const slot = state.probes[probe];
+          slot.last_result = status;
+          if (status === 'success' || status === 'recovered') {
+            slot.last_pass_at  = NOW;
+            slot.last_pass_run = context.runId.toString();
+          } else if (status === 'failure') {
+            slot.last_fail_at  = NOW;
+            slot.last_fail_run = context.runId.toString();
+          } else if (status === 'offline') {
+            state.last_offline_at  = NOW;
+            state.last_offline_run = context.runId.toString();
+          }
+
+          // ---- 5. Render body -------------------------------------------
+          const probeRows = Object.entries(state.probes).map(([k, v]) => {
+            const pass = v.last_pass_at
+              ? `${v.last_pass_at} (run ${v.last_pass_run})`
+              : '—';
+            const fail = v.last_fail_at
+              ? `${v.last_fail_at} (run ${v.last_fail_run})`
+              : '—';
+            return `| \`${k}\` | ${v.last_result || '—'} | ${pass} | ${fail} |`;
+          }).join('\n');
+          const offlineLine = state.last_offline_at
+            ? `**Last offline:** ${state.last_offline_at} (run ${state.last_offline_run})`
+            : '**Last offline:** —';
+
+          const recovery = [
+            '<details><summary>Recovery snippet (run on the host)</summary>',
+            '',
+            '```powershell',
+            'pwsh scripts\\runners\\runner-ctl.ps1 status',
+            'pwsh scripts\\runners\\runner-ctl.ps1 restart',
+            'pwsh scripts\\runners\\runner-ctl.ps1 watchdog status',
+            '```',
+            '',
+            '</details>',
+          ].join('\n');
+
+          const newBody = [
+            `**Runner:** \`${runner}\``,
+            '',
+            offlineLine,
+            '',
+            '| Probe | Last result | Last pass | Last fail |',
+            '| --- | --- | --- | --- |',
+            probeRows || '| — | — | — | — |',
+            '',
+            recovery,
+            '',
+            MARK_S,
+            '```json',
+            JSON.stringify(state, null, 2),
+            '```',
+            MARK_E,
+            trailingNotes ? `\n${trailingNotes}` : '',
+          ].join('\n');
+
+          // ---- 6. Decide open/close + comment ---------------------------
+          const isBadEvent  = status === 'failure' || status === 'offline';
+          const isGoodEvent = status === 'success' || status === 'recovered';
+
+          if (!issue) {
+            if (isBadEvent) {
+              const created = await github.rest.issues.create({
+                ...context.repo,
+                title: TITLE,
+                body: newBody,
+                labels: [LABEL],
+              });
+              issue = created.data;
+              core.info(`Opened sticky issue #${issue.number}.`);
+            } else {
+              core.info('Issue does not exist and probe is healthy; nothing to do.');
+              return;
+            }
+          } else {
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: issue.number,
+              body: newBody,
+            });
+            // Make sure our label is attached.
+            const labelNames = (issue.labels || []).map(l => (typeof l === 'string') ? l : l.name);
+            if (!labelNames.includes(LABEL)) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels: [LABEL],
+              });
+            }
+          }
+
+          if (isBadEvent) {
+            // Reopen if closed.
+            if (issue.state === 'closed') {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'open',
+              });
+              core.info(`Reopened issue #${issue.number}.`);
+            }
+            const commentBody = [
+              `**${probe}** reported \`${status}\` at ${NOW} (${RUN_REF}).`,
+              ctx ? `\n${ctx}` : '',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: issue.number,
+              body: commentBody,
+            });
+          } else if (isGoodEvent && issue.state === 'open') {
+            // All probes green? Close.
+            const allGreen = Object.values(state.probes)
+              .every(p => p.last_result === 'success' || p.last_result === 'recovered');
+            const offlineCleared = !state.last_offline_at
+              || (state.probes[probe] && state.probes[probe].last_pass_at >= state.last_offline_at);
+            if (allGreen && offlineCleared) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `**${probe}** recovered at ${NOW} (${RUN_REF}). Closing.`,
+              });
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              core.info(`Closed issue #${issue.number} (all probes green).`);
+            } else {
+              core.info(`Updated issue #${issue.number}; keeping open (other probes still red).`);
+            }
+          }

--- a/.github/workflows/bootstrap_nninteractive.yml
+++ b/.github/workflows/bootstrap_nninteractive.yml
@@ -1,11 +1,14 @@
 name: Bootstrap nnInteractive
 
 # One-time (or on-demand) installation of the nnInteractive Python backend
-# and (optionally) the SlicerNNInteractive 3D Slicer extension on the
-# AutoResearchClaw self-hosted Mac mini runner.
+# and (optionally) the SlicerNNInteractive 3D Slicer extension on a
+# self-hosted runner. Defaults to the gpu-labelled host (DellXPS-wsl-gpu);
+# override via the `target_label` input.
 #
 # Re-running this workflow is safe — install_nninteractive.sh is idempotent
-# unless `force_reinstall` is set.
+# unless `force_reinstall` is set. Also fires weekly on Monday 11:00 UTC to
+# catch torch / nnInteractive package drift; the weekly probe reports its
+# result to the sticky "Runner health: DellXPS-wsl-gpu" issue.
 
 concurrency:
   group: nninteractive-bootstrap
@@ -14,6 +17,11 @@ concurrency:
 on:
   workflow_dispatch:
     inputs:
+      target_label:
+        description: 'Runner label to target alongside self-hosted (default: gpu, i.e. the XPS).'
+        required: false
+        type: string
+        default: 'gpu'
       force_reinstall:
         description: 'Wipe the existing venv and reinstall from scratch'
         required: false
@@ -34,13 +42,21 @@ on:
         required: false
         type: string
         default: ''
+  schedule:
+    # Mondays 11:00 UTC — catches torch / nnInteractive package drift over
+    # the weekend before the work week starts. Idempotent: if everything
+    # is already installed, this just verifies imports + model presence.
+    - cron: '0 11 * * 1'
 
 jobs:
   bootstrap:
     name: Bootstrap nnInteractive on self-hosted runner
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - ${{ inputs.target_label || 'gpu' }}
     permissions:
       contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -105,3 +121,49 @@ jobs:
           echo "::notice::nnInteractive bootstrap complete."
           echo "Activate the venv with: source $NNINTERACTIVE_HOME/bin/activate"
           echo "Then run: nninteractive_loop.py --input <volume> --goal '<what to segment>'"
+
+      - name: Detect which host ran the job
+        id: whoami
+        if: always()
+        shell: bash
+        run: |
+          # The runner-health issue is keyed by runner name, so we only report
+          # when the job actually landed on DellXPS-wsl-gpu. The runner exports
+          # its own name via $RUNNER_NAME (set by actions-runner itself).
+          echo "runner_name=${RUNNER_NAME:-unknown}" >> "$GITHUB_OUTPUT"
+          echo "Job ran on runner: ${RUNNER_NAME:-unknown}"
+
+      - name: Collect failure context
+        id: collect
+        if: failure() && steps.whoami.outputs.runner_name == 'DellXPS-wsl-gpu'
+        shell: bash
+        run: |
+          {
+            echo "Bootstrap failed in [run ${{ github.run_id }}](${{ github.serverUrl }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            echo ""
+            echo "Likely causes: torch wheel drift after a driver update, nnInteractive package upgrade breaking the venv, model weights moved/corrupted."
+            echo ""
+            echo "Recover by re-running with \`force_reinstall=true\`."
+          } > _health_context.md
+          {
+            echo 'context<<HEALTH_EOF'
+            cat _health_context.md
+            echo 'HEALTH_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report health (success)
+        if: success() && github.event_name == 'schedule' && steps.whoami.outputs.runner_name == 'DellXPS-wsl-gpu'
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: DellXPS-wsl-gpu
+          probe-name: bootstrap
+          status: success
+
+      - name: Report health (failure)
+        if: failure() && steps.whoami.outputs.runner_name == 'DellXPS-wsl-gpu'
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: DellXPS-wsl-gpu
+          probe-name: bootstrap
+          status: failure
+          context: ${{ steps.collect.outputs.context }}

--- a/.github/workflows/runner-liveness.yml
+++ b/.github/workflows/runner-liveness.yml
@@ -1,0 +1,107 @@
+name: Runner liveness
+
+# Out-of-band API-side check that the Dell XPS self-hosted runner is `online`
+# in GitHub's eyes. The on-host watchdog and the systemd Restart= drop-in
+# catch process- and service-level failures, and the scheduled
+# `runner-smoke.yml` catches GPU/Slicer/nnInteractive drift. None of them
+# can catch the case where the runner is fully gone from GitHub's POV
+# (auth lapsed, host hung, network partition) — a self-hosted job would
+# just queue forever without any visible failure.
+#
+# This workflow runs on `ubuntu-latest` (cheap, always available), polls
+# the Actions runners API every 30 min, and opens / updates / closes the
+# single sticky "Runner health" issue.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  # `actions:read` to list self-hosted runners on the repo.
+  actions: read
+
+concurrency:
+  # One liveness check at a time; if cron fires while a previous run is
+  # somehow still in flight, cancel the earlier (we only care about now).
+  group: runner-liveness
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Probe runner status via API
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      RUNNER_NAME: DellXPS-wsl-gpu
+    steps:
+      - name: Checkout (for composite action)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Query runner status
+        id: probe
+        uses: actions/github-script@v8
+        env:
+          RUNNER_NAME: ${{ env.RUNNER_NAME }}
+        with:
+          script: |
+            const target = process.env.RUNNER_NAME;
+            const resp = await github.rest.actions.listSelfHostedRunnersForRepo({
+              ...context.repo,
+              per_page: 100,
+            });
+            const runner = resp.data.runners.find(r => r.name === target);
+            if (!runner) {
+              core.setOutput('exists', 'false');
+              core.setOutput('status', 'missing');
+              core.setOutput('busy', 'false');
+              core.warning(`Runner '${target}' is NOT registered with this repo.`);
+              return;
+            }
+            core.setOutput('exists', 'true');
+            core.setOutput('status', runner.status);  // 'online' | 'offline'
+            core.setOutput('busy', String(runner.busy));
+            core.setOutput('labels', (runner.labels || []).map(l => l.name).join(','));
+            core.info(`Runner '${target}': status=${runner.status} busy=${runner.busy}`);
+            await core.summary
+              .addHeading(`Runner '${target}'`, 2)
+              .addTable([
+                [{data: 'field', header: true}, {data: 'value', header: true}],
+                ['status', runner.status],
+                ['busy', String(runner.busy)],
+                ['os', runner.os || '—'],
+                ['labels', (runner.labels || []).map(l => l.name).join(', ') || '—'],
+              ])
+              .write();
+
+      - name: Report health — offline / missing
+        if: ${{ steps.probe.outputs.status == 'offline' || steps.probe.outputs.status == 'missing' }}
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: ${{ env.RUNNER_NAME }}
+          probe-name: liveness
+          status: offline
+          context: |
+            API reports runner `${{ env.RUNNER_NAME }}` as **${{ steps.probe.outputs.status }}**
+            (`exists=${{ steps.probe.outputs.exists }}`,
+             `busy=${{ steps.probe.outputs.busy }}`).
+
+            On-host recovery:
+
+            ```powershell
+            pwsh scripts\runners\runner-ctl.ps1 status
+            pwsh scripts\runners\runner-ctl.ps1 restart
+            pwsh scripts\runners\runner-ctl.ps1 watchdog status
+            ```
+
+      - name: Report health — online (recovered)
+        if: ${{ steps.probe.outputs.status == 'online' }}
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: ${{ env.RUNNER_NAME }}
+          probe-name: liveness
+          status: recovered

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -28,13 +28,19 @@ on:
         required: false
         type: boolean
         default: false
+  schedule:
+    # Every 6 h at :17 past — off-cycle from common :00 / :30 cron slots
+    # to dodge contention with other repo workflows.
+    - cron: '17 */6 * * *'
 
 concurrency:
-  group: runner-smoke-${{ github.run_id }}
+  # Coalesce scheduled runs but never cancel a manual dispatch.
+  group: runner-smoke-${{ github.event_name == 'schedule' && 'scheduled' || github.run_id }}
   cancel-in-progress: false
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   smoke:
@@ -185,3 +191,50 @@ jobs:
             slicermorph.log
           if-no-files-found: ignore
           retention-days: 14
+
+      - name: Collect failure context
+        id: collect
+        if: failure()
+        shell: bash
+        run: |
+          # Concatenate the tail of each log; the report-runner-health composite
+          # uses this snippet in the issue comment on failure.
+          {
+            echo "Failing job: \`${{ github.job }}\` in [run ${{ github.run_id }}](${{ github.serverUrl }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+            echo ""
+            for f in gpu_smoke.log gpu_smoke_report.json slicer-version.log slicermorph.log; do
+              if [ -s "$f" ]; then
+                echo ""
+                echo "<details><summary><code>$f</code> (last 40 lines)</summary>"
+                echo ""
+                echo '```'
+                tail -40 "$f" || true
+                echo '```'
+                echo ""
+                echo "</details>"
+              fi
+            done
+          } > _health_context.md
+          # Multi-line outputs need the heredoc form.
+          {
+            echo 'context<<HEALTH_EOF'
+            cat _health_context.md
+            echo 'HEALTH_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report health (success)
+        if: success() && github.event_name == 'schedule'
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: DellXPS-wsl-gpu
+          probe-name: runner-smoke
+          status: success
+
+      - name: Report health (failure)
+        if: failure()
+        uses: ./.github/actions/report-runner-health
+        with:
+          runner-name: DellXPS-wsl-gpu
+          probe-name: runner-smoke
+          status: failure
+          context: ${{ steps.collect.outputs.context }}

--- a/docs/self-hosted-gpu-runner.md
+++ b/docs/self-hosted-gpu-runner.md
@@ -173,24 +173,31 @@ smoke test:
   greenlight to flip the other GPU-heavy workflows to
   `[self-hosted, gpu]`).
 
-If/when you later want it to come up at boot, the actions-runner ships a
-systemd unit:
+If/when you later want it to come up at boot, run the bundled installer
+(it wraps `./svc.sh install` and drops in `Restart=on-failure` so a
+crash auto-recovers after 30s):
 
 ```bash
-cd ~/actions-runner-morphoclaw
-sudo ./svc.sh install $USER
-sudo ./svc.sh start
-sudo ./svc.sh status
+bash scripts/runners/install-runner-service.sh
 ```
 
-Plus a tiny Windows Scheduled Task on the host that runs
+Plus a Windows Scheduled Task on the host that keeps WSL itself alive
+and starts the service if it's down — installed once with:
 
-```text
-wsl -d Ubuntu-24.04 -- true
+```powershell
+pwsh scripts\runners\runner-ctl.ps1 watchdog install
 ```
 
-at logon, which is enough to wake the distro so systemd picks the
-runner up.
+The watchdog fires every 5 minutes and at logon; together with the
+systemd drop-in this gives the runner three nested layers of recovery
+(process restart → service restart → host-level wake-up). Day-to-day
+status / log inspection still goes through `runner-ctl.ps1` —
+`pwsh scripts\runners\runner-ctl.ps1 status` reports both the
+systemd-managed and foreground-fallback paths.
+
+> **Caveat:** the Task Scheduler entry runs as the Windows user that
+> installed it. If you change Windows accounts, re-run
+> `runner-ctl.ps1 watchdog install` from the new account.
 
 ## How the workflows find Linux paths
 

--- a/scripts/runners/README.md
+++ b/scripts/runners/README.md
@@ -16,6 +16,10 @@ box with CUDA passthrough (bare metal, WSL2, or LXD/Proxmox VM).
 | `slicer_install_slicermorph.py` | Inside Slicer (via `--python-script`) | Headlessly installs SlicerMorph + a few common companion extensions. |
 | `test-runner.sh` | Inside Ubuntu / WSL2 | Local end-to-end smoke test: nvidia-smi, runner config, PyTorch + CUDA, `nnInteractiveInferenceSession` constructed on the GPU, synthetic forward pass, Slicer headless, `import GPA`. Exits non-zero on the first failure. |
 | `gpu_smoke.py` | Inside the nnInteractive venv | Python helper called by `test-runner.sh` and by `.github/workflows/runner-smoke.yml`. Does the real PyTorch + nnInteractive work. |
+| `install-runner-service.sh` | Inside Ubuntu / WSL2 | Promotes the foreground `./run.sh` runner to a systemd-managed service with `Restart=on-failure` (auto-recovers from crashes after 30s). Idempotent. |
+| `runner-watchdog.ps1` | Windows host (Task Scheduler) | One-shot check: ensures the WSL distro is awake and the runner service is `active`. Restarts whichever is down. Logs to `%LOCALAPPDATA%\MorphoClaw\runner-watchdog.log`. |
+| `install-watchdog.ps1` / `uninstall-watchdog.ps1` | Windows host | Idempotent installer/uninstaller for the `MorphoClaw-RunnerWatchdog` Scheduled Task that runs `runner-watchdog.ps1` every 5 min and at logon. |
+| `runner-ctl.ps1` | Windows host | Unified CLI for status / start / stop / restart / log / dispatch / tail / cancel / token / `watchdog install|uninstall|status|run-once`. |
 | `runner-env.example` | Reference | Sample of the `.env` file the actions-runner reads. Useful for hand-configuring the Mac mini or any other host. |
 
 ## One-shot bring-up (Dell XPS + GTX 1650 Ti, but applies to any Windows + NVIDIA box)
@@ -54,9 +58,22 @@ box with CUDA passthrough (bare metal, WSL2, or LXD/Proxmox VM).
 
 4. **Start the runner:**
 
+   For an ad-hoc foreground run:
+
    ```bash
    cd ~/actions-runner-morphoclaw
    ./run.sh
+   ```
+
+   Or, for the recommended setup (auto-restart on crash + auto-wake on
+   host boot), install it as a systemd service plus a Windows watchdog:
+
+   ```bash
+   bash scripts/runners/install-runner-service.sh
+   ```
+
+   ```powershell
+   pwsh scripts\runners\runner-ctl.ps1 watchdog install
    ```
 
 5. **Verify routing + secrets via GitHub:** trigger the

--- a/scripts/runners/install-runner-service.sh
+++ b/scripts/runners/install-runner-service.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# install-runner-service.sh
+#
+# Promote the GitHub Actions runner from foreground `./run.sh` to a proper
+# systemd service inside WSL Ubuntu, with auto-restart on crash.
+#
+# Run this once, inside WSL, as the user that owns ${RUNNER_DIR}
+# (typically `morphoclaw`). After it finishes:
+#
+#   * the service is enabled (starts on boot of the WSL distro);
+#   * the service is started;
+#   * Restart=on-failure with a 30s backoff is configured via a drop-in;
+#   * `runner-ctl.ps1 status` from the Windows host will report the
+#     systemd-managed state instead of the foreground state.
+#
+# Idempotent: safe to re-run. The drop-in is rewritten each time.
+#
+# Prerequisites:
+#   * setup-wsl-runner.sh has been run (so ${RUNNER_DIR} exists and the
+#     runner is registered against GitHub).
+#   * /etc/wsl.conf has [boot]\nsystemd=true and the distro has been
+#     restarted at least once with `wsl --shutdown` since.
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+RUNNER_DIR="${RUNNER_DIR:-$HOME/actions-runner-morphoclaw}"
+RUNNER_NAME="${RUNNER_NAME:-DellXPS-wsl-gpu}"
+GH_REPO="${GH_REPO:-johntrue15/MorphoClaw}"
+# actions-runner builds the unit name from the repo + runner identity. The
+# actual file is `actions.runner.<owner>-<repo>.<runner-name>.service`.
+SERVICE_NAME="actions.runner.$(echo "$GH_REPO" | tr '/' '-').${RUNNER_NAME}.service"
+DROP_IN_DIR="/etc/systemd/system/${SERVICE_NAME}.d"
+DROP_IN="${DROP_IN_DIR}/restart.conf"
+
+step() { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+ok()   { printf '    \033[1;32m[ok]\033[0m   %s\n' "$*"; }
+warn() { printf '    \033[1;33m[warn]\033[0m %s\n' "$*"; }
+die()  { printf '    \033[1;31m[FAIL]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. Sanity checks
+# ---------------------------------------------------------------------------
+step "1/5 Sanity checks"
+
+if [ ! -d "$RUNNER_DIR" ]; then
+    die "Runner dir not found: $RUNNER_DIR. Run setup-wsl-runner.sh first."
+fi
+if [ ! -x "$RUNNER_DIR/svc.sh" ]; then
+    die "$RUNNER_DIR/svc.sh missing or not executable."
+fi
+if [ ! -f "$RUNNER_DIR/.runner" ]; then
+    die "$RUNNER_DIR/.runner missing ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â runner is not configured. Re-run setup-wsl-runner.sh."
+fi
+if ! command -v systemctl >/dev/null 2>&1; then
+    die "systemctl not found. Enable systemd in /etc/wsl.conf and run 'wsl --shutdown' from PowerShell first."
+fi
+if ! systemctl is-system-running --quiet 2>/dev/null && \
+   [ "$(systemctl is-system-running 2>/dev/null || true)" != "degraded" ]; then
+    # is-system-running prints things like "running", "degraded", "offline".
+    # "offline" means systemd isn't pid 1 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â typical when /etc/wsl.conf is
+    # missing systemd=true or the distro hasn't been restarted.
+    state="$(systemctl is-system-running 2>/dev/null || echo unknown)"
+    if [ "$state" = "offline" ] || [ "$state" = "unknown" ]; then
+        die "systemd is not running inside this WSL distro (state=$state). Ensure /etc/wsl.conf has [boot]\\nsystemd=true and run 'wsl --shutdown' from PowerShell."
+    fi
+fi
+ok "runner dir, svc.sh, .runner, systemctl all present"
+
+# ---------------------------------------------------------------------------
+# 2. Install the bundled systemd unit (idempotent)
+# ---------------------------------------------------------------------------
+step "2/5 Installing systemd unit via ./svc.sh install"
+
+# If the unit already exists, svc.sh refuses to install again. Detect and
+# skip rather than error out ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â we re-apply the drop-in regardless.
+if systemctl list-unit-files --no-pager 2>/dev/null | grep -q "^${SERVICE_NAME}"; then
+    ok "$SERVICE_NAME already installed ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â skipping ./svc.sh install"
+else
+    pushd "$RUNNER_DIR" >/dev/null
+    sudo ./svc.sh install "$USER"
+    popd >/dev/null
+    ok "installed $SERVICE_NAME for user $USER"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Drop in Restart=on-failure / backoff
+# ---------------------------------------------------------------------------
+step "3/5 Writing systemd drop-in $DROP_IN"
+
+sudo mkdir -p "$DROP_IN_DIR"
+sudo tee "$DROP_IN" >/dev/null <<EOF
+# Managed by MorphoClaw scripts/runners/install-runner-service.sh.
+# Re-runs of that script will rewrite this file.
+#
+# StartLimit* must live in [Unit] since systemd v229 â€” putting them in
+# [Service] is silently ignored ("Unknown key name" in journal).
+[Unit]
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Service]
+Restart=on-failure
+RestartSec=30
+EOF
+ok "drop-in written"
+
+sudo systemctl daemon-reload
+ok "systemctl daemon-reload"
+
+# ---------------------------------------------------------------------------
+# 4. Enable + start
+# ---------------------------------------------------------------------------
+step "4/5 Enabling and starting $SERVICE_NAME"
+
+sudo systemctl enable "$SERVICE_NAME"
+sudo systemctl restart "$SERVICE_NAME"
+sleep 3
+
+if systemctl is-active --quiet "$SERVICE_NAME"; then
+    ok "$SERVICE_NAME is active"
+else
+    warn "$SERVICE_NAME not active ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â recent journal entries:"
+    journalctl -u "$SERVICE_NAME" --no-pager -n 30 || true
+    die "service failed to start"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Summary
+# ---------------------------------------------------------------------------
+step "5/5 Done"
+
+cat <<EOF
+
+============================================================================
+ MorphoClaw runner is now managed by systemd.
+============================================================================
+
+  Service: ${SERVICE_NAME}
+  Drop-in: ${DROP_IN}
+  Logs:    journalctl -u ${SERVICE_NAME} -f
+
+Useful commands (run inside WSL):
+
+  systemctl status ${SERVICE_NAME}
+  sudo systemctl restart ${SERVICE_NAME}
+  sudo systemctl stop ${SERVICE_NAME}
+
+Or from the Windows host:
+
+  pwsh scripts\\runners\\runner-ctl.ps1 status
+  pwsh scripts\\runners\\runner-ctl.ps1 restart
+
+If you ever uninstall the runner (./config.sh remove) or re-register it,
+re-run this script to refresh the unit + drop-in.
+
+EOF

--- a/scripts/runners/install-watchdog.ps1
+++ b/scripts/runners/install-watchdog.ps1
@@ -1,0 +1,120 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Install (or refresh) the MorphoClaw runner watchdog Scheduled Task.
+
+.DESCRIPTION
+  Creates a Windows Task Scheduler task that runs runner-watchdog.ps1
+  every 5 minutes and at logon. The task runs as the current user with
+  no elevation — sufficient because:
+
+    * `wsl.exe` works for any user.
+    * The systemd `systemctl start` inside WSL relies on passwordless
+      sudo configured by setup-wsl-runner.sh (NOPASSWD entry for the
+      runner user).
+
+  Idempotent: if a task named MorphoClaw-RunnerWatchdog already exists,
+  it is unregistered and recreated.
+
+.PARAMETER TaskName
+  Name of the Scheduled Task (default: MorphoClaw-RunnerWatchdog).
+
+.PARAMETER IntervalMinutes
+  How often to fire the watchdog (default: 5).
+
+.NOTES
+  Companion uninstaller: uninstall-watchdog.ps1.
+
+  Status / log inspection: `runner-ctl.ps1 watchdog status`.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$TaskName        = 'MorphoClaw-RunnerWatchdog',
+    [int]   $IntervalMinutes = 5
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir  = Split-Path -Parent $PSCommandPath
+$watchdog   = Join-Path $scriptDir 'runner-watchdog.ps1'
+if (-not (Test-Path $watchdog)) {
+    Write-Error "runner-watchdog.ps1 not found next to install-watchdog.ps1 (looked in $scriptDir)."
+    exit 2
+}
+
+Write-Host "Installing scheduled task '$TaskName'" -ForegroundColor Cyan
+Write-Host "  watchdog script:  $watchdog"
+Write-Host "  interval:         every $IntervalMinutes min + at logon"
+
+# --- remove any existing task with this name (idempotent reinstall) -------
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+    Write-Host "  (existing task found; will be replaced)"
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+# --- action ---------------------------------------------------------------
+# powershell.exe is used (not pwsh) to avoid requiring PowerShell 7+ on
+# the host. The watchdog itself supports both.
+$powershell = (Get-Command powershell.exe).Source
+$action = New-ScheduledTaskAction `
+    -Execute $powershell `
+    -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$watchdog`""
+
+# --- triggers -------------------------------------------------------------
+# Trigger 1: every IntervalMinutes, indefinitely. We start "Once" at the
+# current time and add a repetition interval — there is no native "every
+# N minutes forever" trigger in Task Scheduler.
+$triggerInterval = New-ScheduledTaskTrigger -Once -At (Get-Date)
+$triggerInterval.Repetition = (New-CimInstance `
+    -ClassName MSFT_TaskRepetitionPattern `
+    -Namespace Root/Microsoft/Windows/TaskScheduler `
+    -ClientOnly `
+    -Property @{
+        Interval        = "PT${IntervalMinutes}M"
+        Duration        = ""   # empty = indefinitely
+        StopAtDurationEnd = $false
+    })
+
+# Trigger 2: at user logon (matches the user that installs the task).
+$triggerLogon = New-ScheduledTaskTrigger -AtLogOn -User "$env:USERDOMAIN\$env:USERNAME"
+
+# --- principal / settings -------------------------------------------------
+# Run as the current user, interactive (no password store). LIMITED priv
+# level is fine — we don't need admin.
+$principal = New-ScheduledTaskPrincipal `
+    -UserId "$env:USERDOMAIN\$env:USERNAME" `
+    -LogonType Interactive `
+    -RunLevel Limited
+
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 5) `
+    -MultipleInstances IgnoreNew
+
+# --- register -------------------------------------------------------------
+$task = New-ScheduledTask `
+    -Action $action `
+    -Trigger @($triggerInterval, $triggerLogon) `
+    -Principal $principal `
+    -Settings $settings `
+    -Description "MorphoClaw self-hosted runner watchdog. Pokes the WSL distro and restarts the actions-runner systemd service if it's down. See scripts/runners/runner-watchdog.ps1."
+
+Register-ScheduledTask -TaskName $TaskName -InputObject $task | Out-Null
+
+# --- summary --------------------------------------------------------------
+$registered = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+Write-Host ""
+Write-Host "Installed:" -ForegroundColor Green
+$registered | Format-List TaskName, State,
+    @{n='NextRunTime'; e={ (Get-ScheduledTaskInfo $_).NextRunTime }},
+    @{n='LastRunTime'; e={ (Get-ScheduledTaskInfo $_).LastRunTime }}
+
+Write-Host "Log:       $env:LOCALAPPDATA\MorphoClaw\runner-watchdog.log"
+Write-Host "Trigger it manually with:"
+Write-Host "  Start-ScheduledTask -TaskName $TaskName"
+Write-Host "Or from runner-ctl.ps1:"
+Write-Host "  pwsh scripts\runners\runner-ctl.ps1 watchdog run-once"

--- a/scripts/runners/runner-ctl.ps1
+++ b/scripts/runners/runner-ctl.ps1
@@ -31,7 +31,7 @@
 param(
     [Parameter(Mandatory = $true, Position = 0)]
     [ValidateSet('status', 'start', 'stop', 'restart', 'log', 'dispatch',
-                 'runs', 'tail', 'cancel', 'token', 'help')]
+                 'runs', 'tail', 'cancel', 'token', 'watchdog', 'help')]
     [string]$Command,
 
     [Parameter(Position = 1, ValueFromRemainingArguments = $true)]
@@ -109,6 +109,11 @@ Commands:
   tail <run-id>                Stream live logs of a run
   cancel <run-id>              Cancel an in-progress run
   token                        Print a fresh registration token
+  watchdog <subcommand>        Manage the Task Scheduler watchdog:
+                                 install    register MorphoClaw-RunnerWatchdog
+                                 uninstall  remove the scheduled task
+                                 status     show task state + last 20 log lines
+                                 run-once   trigger the watchdog right now
 
 Environment overrides:
   MORPHOCLAW_REPO    (default: johntrue15/MorphoClaw)
@@ -145,8 +150,15 @@ switch ($Command) {
         }
         Write-Host "== Local process view ==" -ForegroundColor Cyan
         Invoke-Wsl @"
-if pgrep -af 'Runner.Listener' >/dev/null; then
-    echo 'state: RUNNING'
+SVC='actions.runner.johntrue15-MorphoClaw.DellXPS-wsl-gpu.service'
+if systemctl is-active --quiet "`$SVC" 2>/dev/null; then
+    echo "state: RUNNING (systemd: \`$SVC)"
+    systemctl --no-pager status "`$SVC" 2>/dev/null | sed -n '1,3p;/Main PID/p;/Active:/p'
+    echo
+    echo '-- last 8 journal entries --'
+    journalctl -u "`$SVC" --no-pager -n 8 2>/dev/null | tail -8
+elif pgrep -af 'Runner.Listener' >/dev/null; then
+    echo 'state: RUNNING (foreground ./run.sh)'
     pgrep -af 'Runner.Listener|run.sh|run-helper' | head -5
     echo
     echo '-- last 10 lines of runner.log --'
@@ -159,38 +171,54 @@ fi
 
     'start' {
         Invoke-Wsl @"
-cd $RunnerDir
-if pgrep -af 'Runner.Listener' >/dev/null; then
-    echo 'Already running:'
-    pgrep -af 'Runner.Listener' | head -3
-    exit 0
+SVC='actions.runner.johntrue15-MorphoClaw.DellXPS-wsl-gpu.service'
+if systemctl list-unit-files --no-pager | grep -q "`$SVC"; then
+    sudo systemctl start "`$SVC"
+    sleep 2
+    systemctl is-active --quiet "`$SVC" && echo "Started (systemd: `$SVC)" || { echo 'FAILED, journal:'; journalctl -u "`$SVC" --no-pager -n 20; exit 1; }
+else
+    cd $RunnerDir
+    if pgrep -af 'Runner.Listener' >/dev/null; then
+        echo 'Already running:'
+        pgrep -af 'Runner.Listener' | head -3
+        exit 0
+    fi
+    setsid nohup ./run.sh > $LogPath 2>&1 < /dev/null &
+    disown
+    sleep 3
+    pgrep -af 'Runner.Listener' | head -3 || { echo 'FAILED to start; see runner.log'; tail -30 $LogPath; exit 1; }
+    echo 'Started (foreground).'
 fi
-setsid nohup ./run.sh > $LogPath 2>&1 < /dev/null &
-disown
-sleep 3
-pgrep -af 'Runner.Listener' | head -3 || { echo 'FAILED to start; see runner.log'; tail -30 $LogPath; exit 1; }
-echo 'Started.'
 "@
     }
 
     'stop' {
         Invoke-Wsl @"
-pids=`$(pgrep -f 'Runner.Listener|run.sh|run-helper' || true)
-if [ -z "`$pids" ]; then
-    echo 'Not running.'
-    exit 0
-fi
-echo "Stopping: `$pids"
-kill `$pids 2>/dev/null || true
-sleep 2
-# force-kill any stragglers
-for p in `$pids; do
-    if kill -0 `$p 2>/dev/null; then
-        kill -9 `$p 2>/dev/null || true
+SVC='actions.runner.johntrue15-MorphoClaw.DellXPS-wsl-gpu.service'
+if systemctl list-unit-files --no-pager | grep -q "`$SVC"; then
+    sudo systemctl stop "`$SVC"
+    sleep 1
+    if systemctl is-active --quiet "`$SVC"; then
+        echo 'Still active!'
+        exit 1
     fi
-done
-sleep 1
-pgrep -af 'Runner.Listener' && { echo 'still alive!'; exit 1; } || echo 'Stopped.'
+    echo "Stopped (systemd: `$SVC)"
+else
+    pids=`$(pgrep -f 'Runner.Listener|run.sh|run-helper' || true)
+    if [ -z "`$pids" ]; then
+        echo 'Not running.'
+        exit 0
+    fi
+    echo "Stopping: `$pids"
+    kill `$pids 2>/dev/null || true
+    sleep 2
+    for p in `$pids; do
+        if kill -0 `$p 2>/dev/null; then kill -9 `$p 2>/dev/null || true; fi
+    done
+    sleep 1
+    if pgrep -af 'Runner.Listener' >/dev/null; then echo 'still alive!'; exit 1; fi
+    echo 'Stopped.'
+fi
 "@
     }
 
@@ -208,7 +236,14 @@ pgrep -af 'Runner.Listener' && { echo 'still alive!'; exit 1; } || echo 'Stopped
                 $i++
             }
         }
-        Invoke-Wsl "tail -n $n $LogPath"
+        Invoke-Wsl @"
+SVC='actions.runner.johntrue15-MorphoClaw.DellXPS-wsl-gpu.service'
+if systemctl list-unit-files --no-pager | grep -q "`$SVC"; then
+    journalctl -u "`$SVC" --no-pager -n $n
+else
+    tail -n $n $LogPath
+fi
+"@
     }
 
     'dispatch' {
@@ -292,5 +327,81 @@ pgrep -af 'Runner.Listener' && { echo 'still alive!'; exit 1; } || echo 'Stopped
         $tok = & gh api -X POST "repos/$Repo/actions/runners/registration-token" --jq .token
         if (-not $tok) { Write-Error 'Failed to mint token.'; exit 3 }
         Write-Host $tok
+    }
+
+    'watchdog' {
+        if ($Rest.Length -eq 0) {
+            Write-Error "Usage: runner-ctl.ps1 watchdog <install|uninstall|status|run-once>"
+            exit 2
+        }
+        $sub      = $Rest[0]
+        $scriptDir = Split-Path -Parent $PSCommandPath
+        $taskName = 'MorphoClaw-RunnerWatchdog'
+        $logPath  = Join-Path $env:LOCALAPPDATA 'MorphoClaw\runner-watchdog.log'
+
+        switch ($sub) {
+            'install' {
+                $installer = Join-Path $scriptDir 'install-watchdog.ps1'
+                if (-not (Test-Path $installer)) {
+                    Write-Error "install-watchdog.ps1 not found at $installer"
+                    exit 3
+                }
+                # `& $installer @extra` is splatting; `& $installer @(...)`
+                # would pass the array as a single positional argument.
+                $extra = @($Rest | Select-Object -Skip 1)
+                & $installer @extra
+            }
+            'uninstall' {
+                $uninstaller = Join-Path $scriptDir 'uninstall-watchdog.ps1'
+                if (-not (Test-Path $uninstaller)) {
+                    Write-Error "uninstall-watchdog.ps1 not found at $uninstaller"
+                    exit 3
+                }
+                $extra = @($Rest | Select-Object -Skip 1)
+                & $uninstaller @extra
+            }
+            'status' {
+                Write-Host "== Scheduled Task '$taskName' ==" -ForegroundColor Cyan
+                $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+                if (-not $task) {
+                    Write-Host "  (not installed; run: runner-ctl.ps1 watchdog install)" -ForegroundColor Yellow
+                } else {
+                    $info = Get-ScheduledTaskInfo -TaskName $taskName
+                    [pscustomobject]@{
+                        State              = $task.State
+                        LastRunTime        = $info.LastRunTime
+                        LastTaskResult     = $info.LastTaskResult
+                        NextRunTime        = $info.NextRunTime
+                        NumberOfMissedRuns = $info.NumberOfMissedRuns
+                    } | Format-List
+                }
+                Write-Host "== Last 20 lines of $logPath ==" -ForegroundColor Cyan
+                if (Test-Path $logPath) {
+                    Get-Content -Path $logPath -Tail 20
+                } else {
+                    Write-Host "  (no log yet)"
+                }
+            }
+            'run-once' {
+                $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+                if (-not $task) {
+                    Write-Host "Task not installed; running watchdog inline." -ForegroundColor Yellow
+                    $watchdog = Join-Path $scriptDir 'runner-watchdog.ps1'
+                    if (-not (Test-Path $watchdog)) {
+                        Write-Error "runner-watchdog.ps1 not found at $watchdog"
+                        exit 3
+                    }
+                    & $watchdog
+                } else {
+                    Start-ScheduledTask -TaskName $taskName
+                    Write-Host "Triggered '$taskName'. Tail the log with:" -ForegroundColor Green
+                    Write-Host "  Get-Content -Wait `"$logPath`""
+                }
+            }
+            default {
+                Write-Error "Unknown watchdog subcommand: $sub. Expected install|uninstall|status|run-once."
+                exit 2
+            }
+        }
     }
 }

--- a/scripts/runners/runner-watchdog.ps1
+++ b/scripts/runners/runner-watchdog.ps1
@@ -1,0 +1,255 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  One-shot health check + auto-recovery for the MorphoClaw WSL runner.
+
+.DESCRIPTION
+  Designed to be invoked every ~5 minutes by Windows Task Scheduler
+  (see install-watchdog.ps1). Each invocation:
+
+    1. Verifies the WSL distro is running; if not, wakes it.
+    2. Checks the actions-runner systemd service is `active`; if not,
+       attempts `systemctl start`.
+    3. Logs every action to %LOCALAPPDATA%\MorphoClaw\runner-watchdog.log
+       (rotated at LogMaxBytes).
+
+  Backoff: tracks recent restart attempts in a sidecar JSON file. If
+  Threshold attempts in WindowSeconds have all failed, the watchdog
+  stops trying for QuietSeconds and writes a "giving up, see issue"
+  line — the GitHub-side liveness check in .github/workflows/runner-liveness.yml
+  takes over from there.
+
+  Exit code is always 0 unless the script itself can't run; we never
+  want a stuck watchdog to spam Task Scheduler with failed history.
+
+.PARAMETER WslDistro
+  WSL distribution name. Defaults to env:MORPHOCLAW_DISTRO or Ubuntu-24.04.
+
+.PARAMETER WslUser
+  Linux user that owns the runner dir. Defaults to env:MORPHOCLAW_USER
+  or `morphoclaw`.
+
+.PARAMETER GhRepo
+  GitHub repo (owner/name). Defaults to env:MORPHOCLAW_REPO or
+  `johntrue15/MorphoClaw`. Used only to build the systemd service name.
+
+.PARAMETER RunnerName
+  Runner name as registered with GitHub. Defaults to env:MORPHOCLAW_RUNNER
+  or `DellXPS-wsl-gpu`.
+
+.NOTES
+  Runs as the current user; no admin needed. The runner service inside
+  WSL was installed by `install-runner-service.sh`, which used
+  `./svc.sh install $USER` — so `sudo systemctl start ...` is the only
+  privileged action, and the WSL user has passwordless sudo for it
+  (configured by setup-wsl-runner.sh).
+#>
+
+[CmdletBinding()]
+param(
+    [string]$WslDistro  = $(if ($env:MORPHOCLAW_DISTRO)  { $env:MORPHOCLAW_DISTRO  } else { 'Ubuntu-24.04' }),
+    [string]$WslUser    = $(if ($env:MORPHOCLAW_USER)    { $env:MORPHOCLAW_USER    } else { 'morphoclaw' }),
+    [string]$GhRepo     = $(if ($env:MORPHOCLAW_REPO)    { $env:MORPHOCLAW_REPO    } else { 'johntrue15/MorphoClaw' }),
+    [string]$RunnerName = $(if ($env:MORPHOCLAW_RUNNER)  { $env:MORPHOCLAW_RUNNER  } else { 'DellXPS-wsl-gpu' }),
+
+    [int]$LogMaxBytes   = 100KB,
+    [int]$Threshold     = 3,
+    [int]$WindowSeconds = 1800,
+    [int]$QuietSeconds  = 1800
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+$StateDir   = Join-Path $env:LOCALAPPDATA 'MorphoClaw'
+$LogPath    = Join-Path $StateDir 'runner-watchdog.log'
+$StatePath  = Join-Path $StateDir 'runner-watchdog-state.json'
+$ServiceName = "actions.runner.$($GhRepo -replace '/', '-').${RunnerName}.service"
+
+if (-not (Test-Path $StateDir)) {
+    New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+function Write-Log {
+    param([string]$Level, [string]$Message)
+    $line = "{0} [{1}] {2}" -f (Get-Date -Format 'yyyy-MM-ddTHH:mm:ss'), $Level, $Message
+    Add-Content -Path $LogPath -Value $line -Encoding utf8
+    # Stream to stdout too (Task Scheduler captures stdout when run interactively).
+    Write-Host $line
+}
+
+function Rotate-Log {
+    if (-not (Test-Path $LogPath)) { return }
+    $size = (Get-Item $LogPath).Length
+    if ($size -le $LogMaxBytes) { return }
+    $archive = "$LogPath.1"
+    if (Test-Path $archive) { Remove-Item $archive -Force }
+    Move-Item $LogPath $archive
+    Write-Log 'INFO' "log rotated (>$($LogMaxBytes) bytes); previous saved to $archive"
+}
+
+function Load-State {
+    if (-not (Test-Path $StatePath)) {
+        return [pscustomobject]@{ attempts = @(); quiet_until = $null }
+    }
+    try {
+        $raw = Get-Content $StatePath -Raw -Encoding utf8
+        return $raw | ConvertFrom-Json
+    } catch {
+        Write-Log 'WARN' "could not parse $StatePath ($_); resetting state"
+        return [pscustomobject]@{ attempts = @(); quiet_until = $null }
+    }
+}
+
+function Save-State {
+    param($State)
+    ($State | ConvertTo-Json -Depth 5) | Set-Content -Path $StatePath -Encoding utf8
+}
+
+function In-QuietPeriod {
+    param($State)
+    if (-not $State.quiet_until) { return $false }
+    try { $until = [datetime]::Parse($State.quiet_until) } catch { return $false }
+    return ((Get-Date) -lt $until)
+}
+
+function Record-Attempt {
+    param($State, [bool]$Success)
+    $nowIso = (Get-Date).ToString('o')
+    $entries = @()
+    foreach ($e in @($State.attempts)) {
+        try { $t = [datetime]::Parse($e.ts) } catch { continue }
+        if (((Get-Date) - $t).TotalSeconds -lt $WindowSeconds) {
+            $entries += $e
+        }
+    }
+    $entries += [pscustomobject]@{ ts = $nowIso; success = $Success }
+    $State.attempts = $entries
+
+    if (-not $Success) {
+        $recentFailures = @($entries | Where-Object { -not $_.success }).Count
+        if ($recentFailures -ge $Threshold) {
+            $quietUntil = (Get-Date).AddSeconds($QuietSeconds)
+            $State.quiet_until = $quietUntil.ToString('o')
+            Write-Log 'WARN' "Threshold of $Threshold failed attempts in $WindowSeconds s reached; backing off until $($quietUntil.ToString('yyyy-MM-ddTHH:mm:ss')). The GitHub-side liveness check will alert if the runner stays offline."
+        }
+    } else {
+        # Success clears the quiet window.
+        $State.quiet_until = $null
+    }
+    return $State
+}
+
+function Invoke-Wsl {
+    param([string]$Bash, [switch]$AsRoot)
+    # We don't use file-based exec here (unlike runner-ctl.ps1) because the
+    # commands are short and the Task Scheduler logon-session may not have
+    # access to %TEMP%. Pipe the script into bash -s instead.
+    $bytes  = [System.Text.Encoding]::UTF8.GetBytes($Bash)
+    $tmp    = [System.IO.Path]::GetTempFileName()
+    try {
+        [System.IO.File]::WriteAllBytes($tmp, $bytes)
+        $args = @('-d', $WslDistro, '-u', $WslUser, '--', 'bash', '-lc',
+                  "cat /mnt/$($tmp.Substring(0,1).ToLower())$(($tmp.Substring(2) -replace '\\','/')) | bash")
+        $out = & wsl.exe @args 2>&1
+        return @{ ExitCode = $LASTEXITCODE; Output = ($out -join "`n") }
+    } finally {
+        if (Test-Path $tmp) { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+function Test-WslDistroRunning {
+    # `wsl --list --running` output is UTF-16 LE — PowerShell handles it fine
+    # but we still trim NULs that occasionally leak through wsl.exe.
+    $listing = (& wsl.exe --list --running 2>$null | Out-String).Replace("`0", '')
+    return $listing -match [regex]::Escape($WslDistro)
+}
+
+function Test-RunnerActive {
+    $r = Invoke-Wsl -Bash "systemctl is-active --quiet '$ServiceName' && echo active || echo inactive"
+    if ($r.ExitCode -ne 0) {
+        # Treat hard failure (wsl.exe error) as inactive so we attempt recovery.
+        Write-Log 'WARN' "is-active probe failed (exit $($r.ExitCode)): $($r.Output)"
+        return $false
+    }
+    return ($r.Output.Trim() -eq 'active')
+}
+
+function Start-RunnerService {
+    Write-Log 'INFO' "attempting: sudo systemctl start $ServiceName"
+    $r = Invoke-Wsl -Bash "sudo -n systemctl start '$ServiceName' 2>&1 || echo FAIL_SUDO"
+    if ($r.Output -match 'FAIL_SUDO|sudo:') {
+        Write-Log 'ERROR' "passwordless sudo not configured for systemctl start. Output: $($r.Output)"
+        return $false
+    }
+    Start-Sleep -Seconds 5
+    return (Test-RunnerActive)
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+try {
+    Rotate-Log
+    $state = Load-State
+
+    if (In-QuietPeriod -State $state) {
+        $remaining = ([datetime]::Parse($state.quiet_until) - (Get-Date)).TotalMinutes
+        Write-Log 'INFO' ("backoff window active, {0:N0} min remaining; skipping run" -f $remaining)
+        exit 0
+    }
+
+    # ---- WSL distro alive? ----
+    if (-not (Test-WslDistroRunning)) {
+        Write-Log 'INFO' "WSL distro '$WslDistro' not running; waking it"
+        # `wsl -- true` keeps the distro alive for the duration of the systemd
+        # boot. We follow up with a real `is-active` probe below.
+        & wsl.exe -d $WslDistro -- true 2>&1 | Out-Null
+        Start-Sleep -Seconds 4
+        if (-not (Test-WslDistroRunning)) {
+            Write-Log 'ERROR' "wake attempt failed; distro still not running"
+            $state = Record-Attempt -State $state -Success:$false
+            Save-State -State $state
+            exit 0
+        }
+        Write-Log 'INFO' "WSL distro is up"
+    }
+
+    # ---- Service active? ----
+    if (Test-RunnerActive) {
+        Write-Log 'INFO' "service $ServiceName active; no action needed"
+        $state = Record-Attempt -State $state -Success:$true
+        Save-State -State $state
+        exit 0
+    }
+
+    Write-Log 'WARN' "service $ServiceName not active; attempting restart"
+    $ok = Start-RunnerService
+
+    if ($ok) {
+        Write-Log 'INFO' "service is now active after restart"
+        $state = Record-Attempt -State $state -Success:$true
+    } else {
+        Write-Log 'ERROR' "service still not active after restart attempt"
+        # Capture last journal lines for diagnosis.
+        $j = Invoke-Wsl -Bash "journalctl -u '$ServiceName' --no-pager -n 15 2>/dev/null || true"
+        if ($j.Output) {
+            Write-Log 'ERROR' "recent journal:`n$($j.Output)"
+        }
+        $state = Record-Attempt -State $state -Success:$false
+    }
+    Save-State -State $state
+    exit 0
+} catch {
+    # Last resort: log and swallow so Task Scheduler doesn't flag the run
+    # as failed (which would clutter its history).
+    try {
+        Write-Log 'ERROR' "uncaught exception: $($_.Exception.Message)"
+    } catch { }
+    exit 0
+}

--- a/scripts/runners/setup-wsl-runner.sh
+++ b/scripts/runners/setup-wsl-runner.sh
@@ -362,12 +362,16 @@ Start the runner (manual, foreground) with:
 
 To check that GitHub sees it: https://github.com/${GH_REPO}/settings/actions/runners
 
-If you want it to start automatically later, you can install the systemd
-unit shipped with the runner:
+If you want it to start automatically (recommended), install the
+service via the wrapper script — it adds Restart=on-failure so a crash
+auto-recovers after 30s:
 
-    cd ${RUNNER_DIR}
-    sudo ./svc.sh install \$USER
-    sudo ./svc.sh start
+    bash scripts/runners/install-runner-service.sh
+
+And on the Windows host, install the Task Scheduler watchdog so a
+stopped WSL distro gets woken up automatically:
+
+    pwsh scripts\runners\runner-ctl.ps1 watchdog install
 
 You can re-run this script anytime; every step is idempotent.
 

--- a/scripts/runners/uninstall-watchdog.ps1
+++ b/scripts/runners/uninstall-watchdog.ps1
@@ -1,0 +1,44 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Remove the MorphoClaw runner watchdog Scheduled Task.
+
+.DESCRIPTION
+  Companion to install-watchdog.ps1. Unregisters the task and leaves
+  the log file alone (so you can still read the history of what it did
+  before being uninstalled).
+
+.PARAMETER TaskName
+  Name of the Scheduled Task (default: MorphoClaw-RunnerWatchdog).
+
+.PARAMETER PurgeLog
+  Also delete %LOCALAPPDATA%\MorphoClaw\runner-watchdog.log and the
+  rotated copy if present.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$TaskName = 'MorphoClaw-RunnerWatchdog',
+    [switch]$PurgeLog
+)
+
+$ErrorActionPreference = 'Stop'
+
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if (-not $task) {
+    Write-Host "No scheduled task named '$TaskName' is registered. Nothing to do." -ForegroundColor Yellow
+} else {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "Unregistered scheduled task '$TaskName'." -ForegroundColor Green
+}
+
+if ($PurgeLog) {
+    $logDir = Join-Path $env:LOCALAPPDATA 'MorphoClaw'
+    foreach ($f in @('runner-watchdog.log', 'runner-watchdog.log.1', 'runner-watchdog-state.json')) {
+        $p = Join-Path $logDir $f
+        if (Test-Path $p) {
+            Remove-Item $p -Force
+            Write-Host "  removed $p"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three nested layers of recovery for the Dell XPS WSL GPU runner so we
stop manually noticing when it's down:

```mermaid
flowchart LR
    subgraph host [Windows host]
        TASK[Task Scheduler<br/>watchdog every 5 min]
    end
    subgraph wsl [WSL Ubuntu]
        SYSD[systemd unit<br/>Restart=on-failure]
        RUNNER[actions-runner]
    end
    subgraph gh [GitHub Actions]
        SMOKE[runner-smoke.yml<br/>schedule: every 6 h]
        LIVE[runner-liveness.yml<br/>schedule: every 30 min<br/>ubuntu-latest]
        BOOT[bootstrap_nninteractive.yml<br/>schedule: Mondays 11:00 UTC]
        ISSUE[sticky 'Runner health: DellXPS-wsl-gpu' issue]
    end
    TASK -- wake WSL,<br/>start svc if dead --> SYSD
    SYSD -- auto-restart on crash --> RUNNER
    SMOKE -- GPU + Slicer probe --> RUNNER
    LIVE -- GET /actions/runners --> gh
    SMOKE --> ISSUE
    LIVE --> ISSUE
    BOOT --> ISSUE
```

## Phases

* **Phase 1 ? systemd-ize the runner inside WSL.**
  `scripts/runners/install-runner-service.sh` wraps `./svc.sh install`
  and drops `Restart=on-failure` / `RestartSec=30` / `StartLimitIntervalSec=600`
  / `StartLimitBurst=5` into a drop-in (`[Unit]` for `StartLimit*`, per systemd v229+).
  Idempotent. Already deployed on the XPS ? `systemctl show` confirms
  `Restart=on-failure`, `RestartUSec=30s`, `StartLimitIntervalUSec=10min`,
  `systemd-analyze verify` clean.

* **Phase 2 ? Windows Task Scheduler watchdog.**
  `scripts/runners/runner-watchdog.ps1` (one-shot) wakes WSL if stopped
  and `sudo systemctl start`s the runner service if it's down. Logs to
  `%LOCALAPPDATA%\MorphoClaw\runner-watchdog.log` (rotated at 100 KB)
  with state-tracked backoff (3 failures in 30 min ? defer to the
  GH-side alerting for 30 min). `install-watchdog.ps1` registers the
  `MorphoClaw-RunnerWatchdog` task (5-min interval + at-logon),
  `uninstall-watchdog.ps1` is the companion. `runner-ctl.ps1` grows
  `watchdog install|uninstall|status|run-once`. Already deployed on the
  XPS ? `LastTaskResult=0`, log shows "service active; no action needed".

* **Phase 3 ? scheduled functional smoke + sticky health issue.**
  `runner-smoke.yml` runs every 6 h (cron `'17 */6 * * *'`). On failure
  or scheduled-success, the new `report-runner-health` composite action
  opens / updates a single sticky issue titled
  `Runner health: DellXPS-wsl-gpu` with a parseable JSON state block
  between AUTO-DATA markers, so multiple probes each update only their
  own slot.

* **Phase 4 ? API-side liveness probe.**
  `runner-liveness.yml` runs on `ubuntu-latest` every 30 min, hits
  `GET /repos/.../actions/runners`, and updates the same sticky issue
  when the runner is `offline` (the only failure mode the on-host
  watchdog and the scheduled smoke both miss). Closes the issue on
  recovery when all probes are green.

* **Phase 5 ? weekly bootstrap drift probe (optional).**
  `bootstrap_nninteractive.yml` gains a Monday 11:00 UTC cron + default
  `target_label=gpu` so the venv is re-validated against the XPS each
  week. Failures append to the same sticky issue. Catches torch wheel
  drift after a driver update or an nnInteractive package upgrade
  breaking the venv.

## Test plan

- [x] Phase 1 deployed on XPS; `systemctl show` properties + `systemd-analyze verify` clean.
- [x] Phase 2 deployed; `runner-ctl.ps1 watchdog status` reports `LastTaskResult=0` and the log shows "service active; no action needed".
- [ ] After merge: wait for the first scheduled `runner-smoke.yml` to run (next `:17` past every 6 h) and confirm no sticky issue is created on success.
- [ ] After merge: wait for the first scheduled `runner-liveness.yml` to run (next `:00` / `:30`) and confirm it reports `status=online` with no issue creation.
- [ ] Verification: stop the runner via `sudo systemctl stop actions.runner....service`, wait <5 min, confirm the watchdog log shows the recovery attempt and the service is back to active. Cleanup: re-start via `runner-ctl.ps1 start`.

## Out of scope

- Multi-runner generalization (XPS-only by design).
- Email / Slack alerting (sticky GitHub issue + the dashboard suffice; can be layered on later).
- Auto-merging fixture re-seeds or scheduling the heavy `nninteractive_compare.yml` ? those are "dev velocity", a separate axis from reliability.
